### PR TITLE
Add workaround for Esprima's failure to tokenize strings with leading '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requires:
   - Node.JS >= 4.0
   - Esprima
     - `npm i esprima`
+    - [Use dev version of Esprima](#use-dev-version-of-esprima)
   - Tensorflow
     - `pip install --upgrade tensorflow`
   - pip
@@ -24,6 +25,13 @@ If you are using `virtualenv`, follow the instructions above, otherwise skip it.
 - `cd /path/to/training-grammar-guru`
 - `virtualenv . -p /home/example_username/opt/python-3.6/bin/python3`
 - `source ./bin/activate`
+
+#### Use dev version of Esprima
+Only the dev version of Esprima is able to [tokenize strings with a leading '/'](https://github.com/jquery/esprima/issues/1895).
+```
+$ ./patch_esprima.sh
+```
+Run this to get `tokenize-js` to use the latest dev version of Esprima.
 
 ### Usage
 To suggest a fix for a file:

--- a/get_dev_esprima.sh
+++ b/get_dev_esprima.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+echo "Creating directory: tokenize-js/node_modules.."
+mkdir -p tokenize-js/node_modules
+
+echo "Cloning Esprima into tokenize-js/node_modules.."
+git clone https://github.com/jquery/esprima.git tokenize-js/node_modules/esprima-dev
+
+cd tokenize-js/node_modules/esprima-dev
+
+echo "Installing Esprima dependencies.."
+npm install
+
+echo "Compiling Esprima.."
+npm run compile
+
+cd ../../..
+
+echo "Done!"
+exit 0

--- a/test.py
+++ b/test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import subprocess
@@ -79,18 +81,17 @@ def test(*, n=None, reset=None, iter=None, **kwargs):
         LOAD_FILES_BIN = (*RANDOM_FILE_BIN, db, str(n))
         subprocess.run(LOAD_FILES_BIN, stdout=subprocess.PIPE)
         print("Files extracted.")
-    
+
     lst_files = []
     for _, _, files in os.walk(SOURCE_DIR):
         for filename in files:
             lst_files.append(filename)
-    
+
     for idx, file in enumerate(lst_files):
-        f = open(SOURCE_DIR + '/' + file, 'r')
-        fStr = f.read()
-        f.close()
-        
-        print('Calculating MRR ' + file + '...')
+        with open(SOURCE_DIR + '/' + file, 'r') as f:
+            fStr = f.read()
+
+        print('Calculating MRR of ' + file + '...')
         ranks_file = []
         for i in range(0, iter):
             (mutant, secret) = mutate(fStr)

--- a/tokenize-js/index.js
+++ b/tokenize-js/index.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const fs = require('fs');
-const esprima = require('esprima');
+const esprima = require('esprima-dev');
 
 module.exports.tokenize = tokenize;
 module.exports.checkSyntax = checkSyntax;


### PR DESCRIPTION
@luizperes 